### PR TITLE
Add ppxlib < 0.36.0 upper bounds to v0.17.x packages to fix compatibility issues

### DIFF
--- a/packages/base_quickcheck/base_quickcheck.v0.17.1/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.17.1/opam
@@ -20,7 +20,7 @@ depends: [
   "ppxlib_jane"       {>= "v0.17" & < "v0.18"}
   "splittable_random" {>= "v0.17" & < "v0.18"}
   "dune"              {>= "3.11.0"}
-  "ppxlib"            {>= "0.36.0"}
+  "ppxlib"            {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Randomized testing framework, designed for compatibility with Base"

--- a/packages/ppx_bench/ppx_bench.v0.17.1/opam
+++ b/packages/ppx_bench/ppx_bench.v0.17.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"           {>= "5.1.0"}
   "ppx_inline_test" {>= "v0.17" & < "v0.18"}
   "dune"            {>= "3.11.0"}
-  "ppxlib"          {>= "0.36.0"}
+  "ppxlib"            {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.17.1/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.17.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_here"    {>= "v0.17" & < "v0.18"}
   "ppxlib_jane" {>= "v0.17" & < "v0.18"}
   "dune"        {>= "3.11.0"}
-  "ppxlib"      {>= "0.36.0"}
+  "ppxlib"      {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Generation of bin_prot readers and writers from types"

--- a/packages/ppx_diff/ppx_diff.v0.17.1/opam
+++ b/packages/ppx_diff/ppx_diff.v0.17.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ppx_jane"      {>= "v0.17" & < "v0.18"}
   "ppxlib_jane"   {>= "v0.17" & < "v0.18"}
   "dune"          {>= "3.11.0"}
-  "ppxlib"        {>= "0.36.0"}
+  "ppxlib"        {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "A PPX rewriter that genreates the implementation of [Ldiffable.S]."

--- a/packages/ppx_expect/ppx_expect.v0.17.3/opam
+++ b/packages/ppx_expect/ppx_expect.v0.17.3/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_inline_test" {>= "v0.17" & < "v0.18"}
   "stdio"           {>= "v0.17" & < "v0.18"}
   "dune"            {>= "3.11.0"}
-  "ppxlib"          {>= "0.36.0"}
+  "ppxlib"          {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 conflicts: [

--- a/packages/ppx_globalize/ppx_globalize.v0.17.2/opam
+++ b/packages/ppx_globalize/ppx_globalize.v0.17.2/opam
@@ -14,7 +14,7 @@ depends: [
   "base"        {>= "v0.17" & < "v0.18"}
   "ppxlib_jane" {>= "v0.17" & < "v0.18"}
   "dune"        {>= "3.11.0"}
-  "ppxlib"      {>= "0.36.0"}
+  "ppxlib"      {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "A ppx rewriter that generates functions to copy local values to the global heap"

--- a/packages/ppx_inline_test/ppx_inline_test.v0.17.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.17.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base"     {>= "v0.17" & < "v0.18"}
   "time_now" {>= "v0.17" & < "v0.18"}
   "dune"     {>= "3.11.0"}
-  "ppxlib"   {>= "0.36.0"}
+  "ppxlib"   {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Syntax extension for writing in-line tests in ocaml code"

--- a/packages/ppx_let/ppx_let.v0.17.1/opam
+++ b/packages/ppx_let/ppx_let.v0.17.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base"     {>= "v0.17" & < "v0.18"}
   "ppx_here" {>= "v0.17" & < "v0.18"}
   "dune"     {>= "3.11.0"}
-  "ppxlib"   {>= "0.36.0"}
+  "ppxlib"   {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Monadic let-bindings"

--- a/packages/ppx_optcomp/ppx_optcomp.v0.17.1/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.17.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base"   {>= "v0.17" & < "v0.18"}
   "stdio"  {>= "v0.17" & < "v0.18"}
   "dune"   {>= "3.11.0"}
-  "ppxlib" {>= "0.36.0"}
+  "ppxlib" {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Optional compilation for OCaml"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.17.1/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.17.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ppxlib_jane" {>= "v0.17" & < "v0.18"}
   "sexplib0"    {>= "v0.17" & < "v0.18"}
   "dune"        {>= "3.11.0"}
-  "ppxlib"      {>= "0.36.0"}
+  "ppxlib"      {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"

--- a/packages/ppx_stable/ppx_stable.v0.17.1/opam
+++ b/packages/ppx_stable/ppx_stable.v0.17.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "5.1.0"}
   "base"   {>= "v0.17" & < "v0.18"}
   "dune"   {>= "3.11.0"}
-  "ppxlib" {>= "0.36.0"}
+  "ppxlib" {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Stable types conversions generator"

--- a/packages/ppx_tydi/ppx_tydi.v0.17.1/opam
+++ b/packages/ppx_tydi/ppx_tydi.v0.17.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"  {>= "5.1.0"}
   "base"   {>= "v0.17" & < "v0.18"}
   "dune"   {>= "3.11.0"}
-  "ppxlib" {>= "0.36.0"}
+  "ppxlib" {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Let expressions, inferring pattern type from expression."

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.17.1/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.17.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base"    {>= "v0.17" & < "v0.18"}
   "typerep" {>= "v0.17" & < "v0.18"}
   "dune"    {>= "3.11.0"}
-  "ppxlib"  {>= "0.36.0"}
+  "ppxlib"  {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Generation of runtime types from type declarations"

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.17.1/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.17.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base"        {>= "v0.17" & < "v0.18"}
   "variantslib" {>= "v0.17" & < "v0.18"}
   "dune"        {>= "3.11.0"}
-  "ppxlib"      {>= "0.36.0"}
+  "ppxlib"      {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Generation of accessor and iteration functions for ocaml variant types"

--- a/packages/ppxlib_jane/ppxlib_jane.v0.17.3/opam
+++ b/packages/ppxlib_jane/ppxlib_jane.v0.17.3/opam
@@ -10,9 +10,9 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "5.3.0"}
+  "ocaml"  {>= "5.3.0"}
   "dune"   {>= "3.11.0"}
-  "ppxlib" {>= "0.36.0"}
+  "ppxlib" {>= "0.28.0" & < "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Utilities for working with Jane Street AST constructs"


### PR DESCRIPTION
- Add upper bound ppxlib < 0.36.0 to all 15 packages from PR #27958
- Addresses compatibility issues with ppxlib >= 0.36.0
- All packages had explicit ppxlib deps, so no conflicts field needed

Modified packages:
- base_quickcheck.v0.17.1
- ppx_bench.v0.17.1
- ppx_bin_prot.v0.17.1
- ppx_diff.v0.17.1
- ppx_expect.v0.17.3
- ppx_globalize.v0.17.2
- ppx_inline_test.v0.17.1
- ppx_let.v0.17.1
- ppx_optcomp.v0.17.1
- ppx_sexp_conv.v0.17.1
- ppx_stable.v0.17.1
- ppx_tydi.v0.17.1
- ppx_typerep_conv.v0.17.1
- ppx_variants_conv.v0.17.1
- ppxlib_jane.v0.17.3